### PR TITLE
[#4] Change to putting only opening bracket when cursor is in front of any character

### DIFF
--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -1,5 +1,6 @@
 let s:QUOTATIONS = doorboy#var#QUOTATIONS
 let s:BRACKETS = doorboy#var#BRACKETS
+let s:CLOSING_BRACKETS = map(deepcopy(s:BRACKETS), 'v:val[1]')
 
 let s:FALSE = 0
 let s:TRUE = !s:FALSE
@@ -9,6 +10,8 @@ let s:BACK = "\<LEFT>"
 let s:BS = "\<BS>"
 let s:DEL = "\<DEL>"
 let s:SPACE = " "
+
+"""""""""" Mapped functions
 
 function! doorboy#mapping#put_quotation(quotation)
   if s:next_char_equals_to(a:quotation)
@@ -23,6 +26,9 @@ endfunction
 function! doorboy#mapping#put_opening_bracket(a_pair_of_brackets)
   if s:next_char_equals_to(a:a_pair_of_brackets[0])
     return s:SKIP
+  endif
+  if s:is_next_char_present() && !s:is_next_char_closing_bracket()
+    return a:a_pair_of_brackets[0]
   endif
   return a:a_pair_of_brackets . s:BACK
 endfunction
@@ -50,6 +56,7 @@ function! doorboy#mapping#space()
   return s:SPACE
 endfunction
 
+"""""""""" Script local functions
 
 function! s:get_prev_char()
   return getline('.')[col('.') - 2]
@@ -71,6 +78,14 @@ function! s:next_char_equals_to(char)
   return s:get_next_char() ==# a:char
 endfunction
 
+function! s:is_next_char_present()
+  return len(s:get_next_char()) > 0 && s:get_next_char() !=# ' '
+endfunction
+
+function! s:is_next_char_closing_bracket()
+  return index(s:CLOSING_BRACKETS, s:get_next_char()) > -1
+endfunction
+
 function! s:is_prev_char_word_char()
   return s:get_prev_char() =~ '\w'
 endfunction
@@ -80,8 +95,7 @@ function! s:is_next_char_word_char()
 endfunction
 
 function! s:is_between_quoations()
-  let prev_char = s:get_prev_char()
-  if !s:is_quotation(prev_char)
+  if !s:is_quotation(s:get_prev_char())
     return s:FALSE
   endif
   return s:next_char_equals_to(s:get_prev_char())

--- a/blankslate.vim
+++ b/blankslate.vim
@@ -1,4 +1,5 @@
 set nocompatible
 set backspace=indent,eol,start
+filetype plugin indent on
 
 setlocal runtimepath+=.

--- a/t/brackets_spec.vim
+++ b/t/brackets_spec.vim
@@ -37,7 +37,7 @@ describe 'doorboy#brackts'
     end
   end
 
-  context 'when cursor is left of opening bracket'
+  context 'when cursor is in front of opening bracket'
     before
       call spec_helper#put_with_cursor('|()')
     end
@@ -46,6 +46,19 @@ describe 'doorboy#brackts'
       it 'should be (SKIP)'
         call spec_helper#insert_chars('(SKIP')
         Expect getline(1) == '(SKIP)'
+      end
+    end
+  end
+
+  context 'when cursor is in front of any character'
+    before
+      call spec_helper#put_with_cursor('|"text"')
+    end
+
+    context 'and putting ('
+      it 'should be ("text"'
+        call spec_helper#insert_chars('(')
+        Expect getline(1) == '("text"'
       end
     end
   end


### PR DESCRIPTION
When: `let @/ = |@z`
Pressing: `(`
Then: `let @/ = (|@z`
