### PR TITLE
[#10] Improve to be customizable for adding/disabling quotation

### DIFF
--- a/after/ftplugin/ruby.vim
+++ b/after/ftplugin/ruby.vim
@@ -1,0 +1,10 @@
+"
+" doorboy.vim
+" after/ftplugin for ruby files
+"
+if exists('b:did_ftplugin_doorboy_ruby')
+  finish
+endif
+let b:did_ftplugin_doorboy_ruby = 1
+
+call doorboy#add_quotation('|')

--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -1,5 +1,5 @@
-let s:QUOTATIONS = doorboy#var#QUOTATIONS
-let s:BRACKETS = doorboy#var#BRACKETS
+let s:QUOTATIONS = doorboy#var#get_quotations()
+let s:BRACKETS = doorboy#var#get_brackets()
 let s:CLOSING_BRACKETS = map(deepcopy(s:BRACKETS), 'v:val[1]')
 
 let s:FALSE = 0
@@ -25,15 +25,15 @@ function! doorboy#mapping#put_quotation(quotation)
   return a:quotation . a:quotation . s:BACK
 endfunction
 
-function! doorboy#mapping#put_opening_bracket(a_pair_of_brackets)
+function! doorboy#mapping#put_opening_bracket(opening_bracket, closing_bracket)
   let next = s:get_next_char()
-  if next ==# a:a_pair_of_brackets[0]
+  if next ==# a:opening_bracket
     return s:SKIP
   endif
   if s:is_present(next) && !s:is_closing_bracket(next)
-    return a:a_pair_of_brackets[0]
+    return a:opening_bracket
   endif
-  return a:a_pair_of_brackets . s:BACK
+  return a:opening_bracket . a:closing_bracket . s:BACK
 endfunction
 
 function! doorboy#mapping#put_closing_bracket(closing_bracket)

--- a/autoload/doorboy/var.vim
+++ b/autoload/doorboy/var.vim
@@ -1,2 +1,10 @@
-let doorboy#var#QUOTATIONS = ['"', "'", "`"]
-let doorboy#var#BRACKETS = ['()', '{}', '[]']
+let s:QUOTATIONS = ['"', "'", "`"]
+let s:BRACKETS = ['()', '{}', '[]']
+
+function! doorboy#var#get_quotations()
+  return s:QUOTATIONS
+endfunction
+
+function! doorboy#var#get_brackets()
+  return s:BRACKETS
+endfunction

--- a/t/customizing_spec.vim
+++ b/t/customizing_spec.vim
@@ -1,0 +1,35 @@
+runtime! plugin/doorboy.vim
+
+source spec_helper.vim
+
+describe 'customizing'
+  before
+    new
+  end
+
+  after
+    close!
+  end
+
+  describe 'doorboy#add_quotation'
+    before
+      call doorboy#add_quotation('|')
+    end
+
+    it 'should add custom quotation properly'
+      call spec_helper#insert_chars('do |x')
+      Expect getline(1) == 'do |x|'
+    end
+  end
+
+  describe 'doorboy#disable_quotation'
+    before
+      call doorboy#disable_quotation('"')
+    end
+
+    it 'should disable specified quotation'
+      call spec_helper#insert_chars('"')
+      Expect getline(1) == '"'
+    end
+  end
+end

--- a/t/ft_ruby_spec.vim
+++ b/t/ft_ruby_spec.vim
@@ -1,0 +1,22 @@
+runtime! plugin/doorboy.vim
+
+source spec_helper.vim
+
+describe 'ftplugin/ruby'
+  before
+    new
+    filetype plugin on
+    set filetype=ruby
+  end
+
+  after
+    close!
+  end
+
+  context 'when putting |ruby'
+    it 'should put |ruby|'
+      call spec_helper#insert_chars('|ruby')
+      Expect getline(1) == '|ruby|'
+    end
+  end
+end


### PR DESCRIPTION
To add custom quotation `call doorboy#add_quotation(char)`
ex.) `call doorboy#add_quotation('|')`

To disable quotation `call doorboy#disable_quotation(char)`
ex.) `call doorboy#disable_quotation('|')`

Bundled it in ruby files with `|`.
