### PR TITLE
[resolve #19] Change not to put quotations twice in regular expression

### DIFF
--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -14,6 +14,9 @@ let s:SPACE = " "
 """""""""" Mapped functions
 
 function! doorboy#mapping#put_quotation(quotation)
+  if s:in_regular_expression()
+    return a:quotation
+  endif
   if s:get_next_char() ==# a:quotation
     return s:SKIP
   endif
@@ -118,4 +121,8 @@ function! s:is_between_brackets_with_spacing()
     return index(s:BRACKETS, s:get_before_prev_and_after_next_chars()) > -1
   endif
   return s:FALSE
+endfunction
+
+function! s:in_regular_expression()
+  return synIDattr(synID(line('.'), col('.'), 0), 'name') =~? 'regexp'
 endfunction

--- a/t/ft_ruby_spec.vim
+++ b/t/ft_ruby_spec.vim
@@ -7,16 +7,29 @@ describe 'ftplugin/ruby'
     new
     filetype plugin on
     set filetype=ruby
+    syntax on
   end
 
   after
     close!
   end
 
-  context 'when putting |ruby'
-    it 'should put |ruby|'
-      call spec_helper#insert_chars('|ruby')
-      Expect getline(1) == '|ruby|'
+  describe 'putting |'
+    context 'NOT in a regular expression'
+      it 'should put ||<LEFT>'
+        call spec_helper#insert_chars('|ruby')
+        Expect getline(1) == '|ruby|'
+      end
+    end
+
+    context 'in a regular expression'
+      before
+        call spec_helper#put_with_cursor('/(|)/')
+      end
+      it 'should put |'
+        call spec_helper#insert_chars('|ruby')
+        Expect getline(1) == '/(|ruby)/'
+      end
     end
   end
 end


### PR DESCRIPTION
(# is the cursor)
When: `/(#)/`
Type: `|`
Then:
- Before: `/(|#|)/`
- Now: `/(|#)/`

No need to repeat.
