### PR TITLE
Changed to auto closing when the cursor is in front of a separator character

### DIFF
--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -99,10 +99,6 @@ function! s:is_present(char)
   return len(a:char) > 0 && a:char !~ '\s'
 endfunction
 
-function! s:is_closing_bracket(char)
-  return index(doorboy#var#get_closing_bracktes(&filetype), a:char) > -1
-endfunction
-
 function! s:is_between_quoations()
   let prev_char = s:get_prev_char()
   if !s:is_quotation(prev_char)

--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -6,6 +6,8 @@ let s:BACK = "\<LEFT>"
 let s:BS = "\<BS>"
 let s:DEL = "\<DEL>"
 let s:SPACE = " "
+let s:SEPARATOR_L_EXP = '\v%([\({\[>,\.=]|\s|^)$'
+let s:SEPARATOR_R_EXP = '\v^%([\)}\]>,\.=]|\s|$)'
 
 """""""""" Mapped functions
 
@@ -16,10 +18,10 @@ function! doorboy#mapping#put_quotation(quotation)
   if s:in_regular_expression()
     return a:quotation
   endif
-  if s:get_left_str() !~ '\v%([\({\[>,\.=]|\s|^)$'
+  if s:get_left_str() !~ s:SEPARATOR_L_EXP
     return a:quotation
   endif
-  if s:get_right_str() !~ '\v^%([\)}\]>,\.=]|\s|$)'
+  if s:get_right_str() !~ s:SEPARATOR_R_EXP
     return a:quotation
   endif
   return a:quotation . a:quotation . s:BACK
@@ -30,7 +32,7 @@ function! doorboy#mapping#put_opening_bracket(opening_bracket, closing_bracket)
   if next_char ==# a:opening_bracket
     return s:SKIP
   endif
-  if s:is_present(next_char) && !s:is_closing_bracket(next_char)
+  if s:is_present(next_char) && next_char !~ s:SEPARATOR_R_EXP
     return a:opening_bracket
   endif
   return a:opening_bracket . a:closing_bracket . s:BACK

--- a/t/brackets_spec.vim
+++ b/t/brackets_spec.vim
@@ -46,7 +46,7 @@ describe 'brackts'
     end
   end
 
-  context 'when cursor is in front of any character'
+  context 'when cursor is in front of word character'
     before
       call spec_helper#put_with_cursor('|"text"')
     end
@@ -55,6 +55,19 @@ describe 'brackts'
       it 'should put ( once'
         call spec_helper#insert_chars('(')
         Expect getline(1) == '("text"'
+      end
+    end
+  end
+
+  context 'when cursor is in front of separator character'
+    before
+      call spec_helper#put_with_cursor('|,')
+    end
+
+    context 'and putting ('
+      it 'should put ( twice'
+        call spec_helper#insert_chars('(')
+        Expect getline(1) == '(),'
       end
     end
   end


### PR DESCRIPTION
When: `t|,`
Type: `(`
Then: `t(|),`
