### PR TITLE
Add mapping '#' to insert #{|} in ruby strings

### DIFF
--- a/after/ftplugin/eruby.vim
+++ b/after/ftplugin/eruby.vim
@@ -4,7 +4,7 @@ endif
 let b:did_ftplugin_doorboy_eruby = 1
 
 function! s:put_ruby_quotation(quotation)
-  if synIDattr(synID(line('.'), col('.') - 1, 0), 'name') =~? 'eruby'
+  if doorboy#util#current_synIDattr_name() =~? 'eruby'
     return doorboy#mapping#put_quotation(a:quotation)
   endif
   return a:quotation

--- a/after/ftplugin/ruby.vim
+++ b/after/ftplugin/ruby.vim
@@ -3,4 +3,12 @@ if exists('b:did_ftplugin_doorboy_ruby')
 endif
 let b:did_ftplugin_doorboy_ruby = 1
 
+function! s:put_interpolation_in_string(char)
+  if doorboy#util#in_double_quotation_string()
+    return a:char . "{}" . "\<LEFT>"
+  endif
+  return a:char
+endfunction
+
 call doorboy#add_quotations('ruby', ['|', '/'])
+inoremap <buffer> <expr> # <SID>put_interpolation_in_string('#')

--- a/after/ftplugin/slim.vim
+++ b/after/ftplugin/slim.vim
@@ -9,7 +9,7 @@ endif
 let b:did_ftplugin_doorboy_slim = 1
 
 function! s:put_ruby_quotation(quotation)
-  if synIDattr(synID(line('.'), col('.') - 1, 0), 'name') =~? 'ruby'
+  if doorboy#util#current_synIDattr_name() =~? 'ruby'
     return doorboy#mapping#put_quotation(a:quotation)
   endif
   return a:quotation

--- a/after/ftplugin/vim.vim
+++ b/after/ftplugin/vim.vim
@@ -11,8 +11,7 @@ function! s:put_double_quotation()
 endfunction
 
 function! s:is_beginning_of_line()
-  let left_str = strpart(getline('.'), 0, col('.') - 1)
-	return left_str =~ "^\\s\*$"
+	return doorboy#util#get_left_str() =~ "^\\s\*$"
 endfunction
 
 inoremap <buffer> <expr> " <SID>put_double_quotation()

--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -10,23 +10,23 @@ let s:SPACE = " "
 """""""""" Mapped functions
 
 function! doorboy#mapping#put_quotation(quotation)
-  if s:get_next_char() ==# a:quotation
+  if doorboy#util#get_next_char() ==# a:quotation
     return s:SKIP
   endif
-  if s:in_regular_expression()
+  if doorboy#util#in_regular_expression()
     return a:quotation
   endif
-  if s:get_left_str() !~ s:get_separator_l_exp()
+  if doorboy#util#get_left_str() !~ s:get_separator_l_exp()
     return a:quotation
   endif
-  if s:get_right_str() !~ s:get_separator_r_exp()
+  if doorboy#util#get_right_str() !~ s:get_separator_r_exp()
     return a:quotation
   endif
   return a:quotation . a:quotation . s:BACK
 endfunction
 
 function! doorboy#mapping#put_opening_bracket(opening_bracket, closing_bracket)
-  let next_char = s:get_next_char()
+  let next_char = doorboy#util#get_next_char()
   if next_char ==# a:opening_bracket
     return s:SKIP
   endif
@@ -37,91 +37,30 @@ function! doorboy#mapping#put_opening_bracket(opening_bracket, closing_bracket)
 endfunction
 
 function! doorboy#mapping#put_closing_bracket(closing_bracket)
-  if s:get_next_char() ==# a:closing_bracket
+  if doorboy#util#get_next_char() ==# a:closing_bracket
     return s:SKIP
   endif
   return a:closing_bracket
 endfunction
 
 function! doorboy#mapping#backspace()
-  if         s:is_between_quoations()
-        \ || s:is_between_brackets()
-        \ || s:is_between_brackets_with_spacing()
+  if         doorboy#util#is_between_quoations()
+        \ || doorboy#util#is_between_brackets()
+        \ || doorboy#util#is_between_brackets_with_spacing()
     return s:BS . s:DEL
   endif
   return s:BS
 endfunction
 
 function! doorboy#mapping#space()
-  if s:is_between_brackets()
+  if doorboy#util#is_between_brackets()
     return s:SPACE . s:SPACE . s:BACK
   endif
   return s:SPACE
 endfunction
 
-"""""""""" Script local functions
-
-function! s:prev_char_index()
-  return col('.') - 2
-endfunction
-
-function! s:next_char_index()
-  return col('.') - 1
-endfunction
-
-function! s:get_prev_char()
-  return getline('.')[s:prev_char_index()]
-endfunction
-
-function! s:get_next_char()
-  return getline('.')[s:next_char_index()]
-endfunction
-
-function! s:get_left_str()
-  return strpart(getline('.'), 0, col('.') - 1)
-endfunction
-
-function! s:get_right_str()
-  return getline('.')[ s:next_char_index() : -1 ]
-endfunction
-
-function! s:get_prev_and_next_chars()
-  return s:get_prev_char() . s:get_next_char()
-endfunction
-
-function! s:get_before_prev_and_after_next_chars()
-  return getline('.')[s:prev_char_index() - 1] . getline('.')[s:next_char_index() + 1]
-endfunction
-
 function! s:is_present(char)
   return len(a:char) > 0 && a:char !~ '\s'
-endfunction
-
-function! s:is_between_quoations()
-  let prev_char = s:get_prev_char()
-  if !s:is_quotation(prev_char)
-    return s:FALSE
-  endif
-  return s:get_next_char() ==# prev_char
-endfunction
-
-function! s:is_quotation(char)
-  return index(doorboy#var#get_quotations(&filetype), a:char) > -1
-endfunction
-
-function! s:is_between_brackets()
-  return index(doorboy#var#get_brackets(&filetype), s:get_prev_and_next_chars()) > -1
-endfunction
-
-function! s:is_between_brackets_with_spacing()
-  if s:get_prev_char() ==# s:SPACE && s:get_next_char() ==# s:SPACE
-    return index(doorboy#var#get_brackets(&filetype), s:get_before_prev_and_after_next_chars()) > -1
-  endif
-  return s:FALSE
-endfunction
-
-function! s:in_regular_expression()
-  return synIDattr(synID(line('.'), col('.'), 0), 'name') =~? 'regexp'
 endfunction
 
 "

--- a/autoload/doorboy/util.vim
+++ b/autoload/doorboy/util.vim
@@ -1,0 +1,81 @@
+let s:FALSE = 0
+let s:TRUE = !s:FALSE
+
+let s:SPACE = " "
+
+
+function! doorboy#util#get_next_char()
+  return getline('.')[s:next_char_index()]
+endfunction
+
+function! doorboy#util#get_left_str()
+  return strpart(getline('.'), 0, s:next_char_index())
+endfunction
+
+function! doorboy#util#get_right_str()
+  return getline('.')[ s:next_char_index() : -1 ]
+endfunction
+
+function! doorboy#util#is_between_quoations()
+  let prev_char = s:get_prev_char()
+  if !s:is_quotation(prev_char)
+    return s:FALSE
+  endif
+  return doorboy#util#get_next_char() ==# prev_char
+endfunction
+
+function! doorboy#util#is_between_brackets()
+  return index(doorboy#var#get_brackets(&filetype), s:get_prev_and_next_chars()) > -1
+endfunction
+
+function! doorboy#util#is_between_brackets_with_spacing()
+  if s:get_prev_char() ==# s:SPACE && doorboy#util#get_next_char() ==# s:SPACE
+    return index(doorboy#var#get_brackets(&filetype), s:get_before_prev_and_after_next_chars()) > -1
+  endif
+  return s:FALSE
+endfunction
+
+function! doorboy#util#current_synIDattr_name()
+  return synIDattr(synID(line('.'), s:next_char_index(), 0), 'name')
+endfunction
+
+function! doorboy#util#in_regular_expression()
+  return doorboy#util#current_synIDattr_name() =~? 'regexp'
+endfunction
+
+function! doorboy#util#in_double_quotation_string()
+  if doorboy#util#current_synIDattr_name() !~? 'string'
+    return s:FALSE
+  endif
+  let left_str = doorboy#util#get_left_str()
+  let double_quotation_count = count(matchlist(left_str, '\("\)'), '"') - 1
+  if double_quotation_count > 0 && fmod(double_quotation_count, 2) == 1
+    return s:TRUE
+  endif
+  return s:FALSE
+endfunction
+
+
+function! s:prev_char_index()
+  return col('.') - 2
+endfunction
+
+function! s:next_char_index()
+  return col('.') - 1
+endfunction
+
+function! s:get_prev_char()
+  return getline('.')[s:prev_char_index()]
+endfunction
+
+function! s:get_prev_and_next_chars()
+  return s:get_prev_char() . doorboy#util#get_next_char()
+endfunction
+
+function! s:get_before_prev_and_after_next_chars()
+  return getline('.')[s:prev_char_index() - 1] . getline('.')[s:next_char_index() + 1]
+endfunction
+
+function! s:is_quotation(char)
+  return index(doorboy#var#get_quotations(&filetype), a:char) > -1
+endfunction

--- a/t/ft_ruby_spec.vim
+++ b/t/ft_ruby_spec.vim
@@ -25,7 +25,7 @@ describe 'ftplugin/ruby'
     end
   end
 
-  context 'in a regular expression'
+  context 'when in regular expression'
     context 'and in front of NOT /'
       before
         call spec_helper#put_with_cursor('/(|)/')
@@ -45,6 +45,31 @@ describe 'ftplugin/ruby'
         it 'should skip'
           call spec_helper#insert_chars('/ =~')
           Expect getline(1) == '/ruby/ =~'
+        end
+      end
+    end
+  end
+
+  context 'when in string literals'
+    context 'and srrounded by "'
+      before
+        call spec_helper#put_with_cursor('"|"')
+      end
+      context 'and putting #var'
+        it 'should put #{}<LEFT>'
+          call spec_helper#insert_chars('#var')
+          Expect getline(1) == '"#{var}"'
+        end
+      end
+    end
+    context "and srrounded by '"
+      before
+        call spec_helper#put_with_cursor("'|'")
+      end
+      context 'and putting #'
+        it 'should just put #'
+          call spec_helper#insert_chars('#')
+          Expect getline(1) == "'#'"
         end
       end
     end


### PR DESCRIPTION
When: `"|"` in ruby syntax
Put: `#`
Then: `"#{|}"`
