### PR TITLE
Added ability to expand abbreviations

### DIFF
--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -108,7 +108,7 @@ function! s:get_separator_r_exp()
 endfunction
 
 "
-" Returns s:EXPAND_ABBR if char is a keyword character, '' otherwise.
+" Returns s:EXPAND_ABBR if char is not a keyword character, '' otherwise.
 "
 function! s:get_expand_abbr(char)
   if match(a:char, '\k') == -1

--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -12,40 +12,45 @@ let s:CR = "\<CR>"
 let s:UP = "\<UP>"
 let s:TAB = "\<TAB>"
 
+let s:EXPAND_ABBR = "\<C-]>"
+
 """""""""" Mapped functions
 
 function! doorboy#mapping#put_quotation(quotation)
+  let l:expand_abbr = s:get_expand_abbr(quotation)
   if doorboy#util#get_next_char() ==# a:quotation
-    return s:SKIP
+    return s:expand_abbr() . s:SKIP
   endif
   if doorboy#util#in_regular_expression()
-    return a:quotation
+    return l:expand_abbr . a:quotation
   endif
   if doorboy#util#get_left_str() !~ s:get_separator_l_exp()
-    return a:quotation
+    return l:expand_abbr . a:quotation
   endif
   if doorboy#util#get_right_str() !~ s:get_separator_r_exp()
-    return a:quotation
+    return l:expand_abbr . a:quotation
   endif
-  return a:quotation . a:quotation . s:BACK
+  return l:expand_abbr . a:quotation . a:quotation . s:BACK
 endfunction
 
 function! doorboy#mapping#put_opening_bracket(opening_bracket, closing_bracket)
   let next_char = doorboy#util#get_next_char()
+  let l:expand_abbr = s:get_expand_abbr(a:opening_bracket)
   if next_char ==# a:opening_bracket
-    return s:SKIP
+    return l:expand_abbr . s:SKIP
   endif
   if s:is_present(next_char) && next_char !~ s:get_separator_r_exp()
-    return a:opening_bracket
+    return l:expand_abbr . a:opening_bracket
   endif
-  return a:opening_bracket . a:closing_bracket . s:BACK
+  return l:expand_abbr . a:opening_bracket . a:closing_bracket . s:BACK
 endfunction
 
 function! doorboy#mapping#put_closing_bracket(closing_bracket)
+  let l:expand_abbr = s:get_expand_abbr(a:closing_bracket)
   if doorboy#util#get_next_char() ==# a:closing_bracket
-    return s:SKIP
+    return l:expand_abbr . s:SKIP
   endif
-  return a:closing_bracket
+  return l:expand_abbr . a:closing_bracket
 endfunction
 
 function! doorboy#mapping#backspace()
@@ -58,17 +63,19 @@ function! doorboy#mapping#backspace()
 endfunction
 
 function! doorboy#mapping#space()
+  let l:expand_abbr = s:get_expand_abbr(expand(s:SPACE))
   if doorboy#util#is_between_brackets()
-    return s:SPACE . s:SPACE . s:BACK
+    return l:expand_abbr . s:SPACE . s:SPACE . s:BACK
   endif
-  return s:SPACE
+  return l:expand_abbr . s:SPACE
 endfunction
 
 function! doorboy#mapping#cr()
+  let l:expand_abbr = s:get_expand_abbr(expand(s:CR))
   if doorboy#util#is_between_brackets()
-    return s:CR . s:CR . s:UP . s:TAB
+    return l:expand_abbr . s:CR . s:CR . s:UP . s:TAB
   endif
-  return s:CR
+  return l:expand_abbr . s:CR
 endfunction
 
 function! s:is_present(char)
@@ -98,4 +105,14 @@ function! s:get_separator_r_exp()
     return b:separator_r_exp
   endif
   return '\v^%([\)}\]>,\.=/]|\s|$)'
+endfunction
+
+"
+" Returns s:EXPAND_ABBR if char is a keyword character, '' otherwise.
+"
+function! s:get_expand_abbr(char)
+  if match(a:char, '\k') == -1
+    return s:EXPAND_ABBR
+  endif
+  return ''
 endfunction

--- a/autoload/doorboy/mapping.vim
+++ b/autoload/doorboy/mapping.vim
@@ -19,7 +19,7 @@ let s:EXPAND_ABBR = "\<C-]>"
 function! doorboy#mapping#put_quotation(quotation)
   let l:expand_abbr = s:get_expand_abbr(quotation)
   if doorboy#util#get_next_char() ==# a:quotation
-    return s:expand_abbr() . s:SKIP
+    return l:expand_abbr . s:SKIP
   endif
   if doorboy#util#in_regular_expression()
     return l:expand_abbr . a:quotation


### PR DESCRIPTION
This adds the ability for doorboy mappings to expand abbreviations.

This is implemented using a new function get_expand_abbr(), which takes a character and returns "\<C-]>" (see :help abbreviations) if it is not in &iskeyword.